### PR TITLE
Improve primitive shapes in iCubGazeboSimpleCollisionsV2_5

### DIFF
--- a/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/icub_simple_collisions.urdf
+++ b/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/icub_simple_collisions.urdf
@@ -19,9 +19,9 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.035 0 -0.065" rpy="0 0 0"/>
+      <origin xyz="0.04 0 -0.05" rpy="0 0 0"/>
       <geometry>
-    	    <box size="0.16 0.22 0.16" />
+    	    <box size="0.13 0.2 0.13" />
       </geometry>
     </collision>
   </link>
@@ -128,6 +128,12 @@
         <color rgba="1 1 0 1"/>
       </material>
     </visual>
+    <collision>
+      <origin xyz="0.005 -0.002 -0.04" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="0.16" radius="0.06"/>
+      </geometry>
+    </collision>
   </link>
   <joint name="r_hip_yaw" type="revolute">
     <origin xyz="0 0 0.0144" rpy="-3.14159265359 0 0"/>
@@ -172,10 +178,9 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.005 0 -0.08"
-              rpy="1.57079632679 0 1.57079632679"/>
+      <origin xyz="0.005 -0.002 -0.08" rpy="0 0 0"/>
       <geometry>
-	    <box size="0.12 0.2 0.12" />
+        <cylinder length="0.20" radius="0.056" />
       </geometry>
     </collision>
   </link>
@@ -390,6 +395,12 @@
         <color rgba="0 1 0 1"/>
       </material>
     </visual>
+    <collision>
+      <origin xyz="0.005 0.002 -0.04" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="0.16" radius="0.06"/>
+      </geometry>
+    </collision>
   </link>
   <joint name="l_hip_yaw" type="revolute">
     <origin xyz="0 0 0.0144" rpy="-3.14159265359 0 0"/>
@@ -434,10 +445,9 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.005 0 -0.08"
-              rpy="1.57079632679 0 1.57079632679"/>
+      <origin xyz="0.005 0.002 -0.08" rpy="0 0 0"/>
       <geometry>
-	    <box size="0.12 0.2 0.12" />
+        <cylinder length="0.20" radius="0.056" />
       </geometry>
     </collision>
   </link>
@@ -620,9 +630,9 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0.065 -0.054" rpy="0 0 0"/>
+      <origin xyz="0 0.06 -0.054" rpy="0 0 0"/>
       <geometry>
-	    <box size="0.2 0.2 0.30" />
+	    <box size="0.15 0.18 0.26" />
       </geometry>
     </collision>
   </link>
@@ -737,6 +747,12 @@
         <color rgba="0.5 0.5 0.5 1"/>
       </material>
     </visual>
+    <collision>
+      <origin xyz="-0.02 0 0.028" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="0.13" radius="0.047"/>
+      </geometry>
+    </collision>
   </link>
   <joint name="r_arm_ft_sensor" type="fixed">
     <origin xyz="-0.0508973017665 0 0.0291670296206" rpy="0 -1.30899700697 0"/>
@@ -789,10 +805,10 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="-0.04 0 0"
-              rpy="0 0.3 0"/>
+      <origin xyz="-0.045 0 0.01"
+              rpy="0 1.87 0"/>
       <geometry>
-	    <box size="0.13 0.08 0.1" />
+        <cylinder length="0.12" radius="0.04"/>
       </geometry>
     </collision>
   </link>
@@ -857,6 +873,12 @@
         <color rgba="0 0 1 1"/>
       </material>
     </visual>
+    <collision>
+        <origin xyz="-0.09 0 0.02" rpy="0 0.3 0"/>
+        <geometry>
+          <box size="0.14 0.05 0.07"/>
+        </geometry>
+    </collision>
   </link>
   <joint name="r_wrist_yaw" type="revolute">
     <origin xyz="0.000634106499644 -0.0194999 0.00236651831751" rpy="0 0 0"/>
@@ -975,6 +997,12 @@
         <color rgba="0 1 0 1"/>
       </material>
     </visual>
+    <collision>
+      <origin xyz="-0.02 0 0.028" rpy="0 0 0"/>
+      <geometry>
+        <cylinder length="0.13" radius="0.047"/>
+      </geometry>
+    </collision>
   </link>
   <joint name="l_arm_ft_sensor" type="fixed">
     <origin xyz="0.0509301432452 0 0.0291758294659"
@@ -1028,10 +1056,10 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.04 0 0"
-              rpy="0 -0.3 0"/>
+      <origin xyz="0.045 0 0.01"
+              rpy="0 -1.87 0"/>
       <geometry>
-	    <box size="0.13 0.08 0.1" />
+        <cylinder length="0.12" radius="0.04"/>
       </geometry>
     </collision>
   </link>
@@ -1096,6 +1124,12 @@
         <color rgba="0.5 0.5 0.5 1"/>
       </material>
     </visual>
+    <collision>
+        <origin xyz="0.09 0 0.02" rpy="0 -0.3 0"/>
+        <geometry>
+          <box size="0.14 0.05 0.07"/>
+        </geometry>
+    </collision>
   </link>
   <joint name="l_wrist_yaw" type="revolute">
     <origin xyz="-0.000634106499644 -0.0194999 0.00236651831751" rpy="0 0 0"/>
@@ -1186,10 +1220,10 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0.13 -0.016"
+      <origin xyz="0 0.12 -0.02"
               rpy="0 0 0"/>
       <geometry>
-	    <box size="0.18 0.18 0.215" />
+	    <sphere radius="0.11" />
       </geometry>
     </collision>
   </link>

--- a/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/icub_simple_collisions.urdf
+++ b/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/icub_simple_collisions.urdf
@@ -1414,6 +1414,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>5</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="torso_1">
     <visual>
@@ -1435,6 +1442,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>24674</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="neck_1">
     <visual>
@@ -1456,6 +1470,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>6553</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="l_hip_1">
     <visual>
@@ -1484,6 +1505,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>18</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="l_lower_leg">
     <visual>
@@ -1491,6 +1519,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>73</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="l_ankle_1">
     <visual>
@@ -1512,6 +1547,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>294</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="l_shoulder_1">
     <visual>
@@ -1540,6 +1582,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>1433</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="l_elbow_1">
     <visual>
@@ -1554,6 +1603,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>4710</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="l_wrist_1">
     <visual>
@@ -1568,6 +1624,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>18841</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="r_hip_1">
     <visual>
@@ -1596,6 +1659,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>10</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="r_lower_leg">
     <visual>
@@ -1603,6 +1673,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>49</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="r_ankle_1">
     <visual>
@@ -1624,6 +1701,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>198</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="r_shoulder_1">
     <visual>
@@ -1652,6 +1736,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>921</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="r_elbow_1">
     <visual>
@@ -1666,6 +1757,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>3174</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <gazebo reference="r_wrist_1">
     <visual>
@@ -1680,6 +1778,13 @@
         <diffuse>1 1 1 1</diffuse>
       </material>
     </visual>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>12697</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
 
 </robot>


### PR DESCRIPTION
- Use better primitive shapes than #15 
- Added collisions also for upper arms and upper legs

Keep in mind that collisions [are disabled by default](http://sdformat.org/spec?ver=1.6&elem=model#model_self_collide) between parent-child links of a joint.

<details>
<summary>Images in Gazebo Classic</summary>

![front](https://user-images.githubusercontent.com/469199/84760502-6b7e9800-afc8-11ea-980a-83ccf80b3652.jpeg)
![side](https://user-images.githubusercontent.com/469199/84760503-6c172e80-afc8-11ea-9131-36327d151123.jpeg)
![detail](https://user-images.githubusercontent.com/469199/84760496-6ae60180-afc8-11ea-98d5-1dcaf5ae70f5.jpeg)

</details>

I tried to run the following code in Ignition Gazebo (it requires `gym_pushrecovery` that is not yet open source):

```python
import time
import gym_ignition_models
from gym_pushrecovery import models
from gym_ignition.utils import scenario

gazebo, world = scenario.init_gazebo_sim()

icub = models.icub.ICubGazeboSimpleCollisions(
    world=world,
    model_file=gym_ignition_models.get_model_file("iCubGazeboSimpleCollisionsV2_5"))

assert icub.self_collisions_enabled()

gazebo.gui()
time.sleep(3)
gazebo.run(paused=True)
time.sleep(10)

links_in_contact = icub.links_in_contact()

for _ in range(2000):
    gazebo.run()
    new = icub.links_in_contact()

    if new != links_in_contact:
        links_in_contact = new
        print(links_in_contact)
        time.sleep(0.2)

time.sleep(5)
```

and it seems working fine (requires https://github.com/robotology/gym-ignition/pull/212). However, contact detection is not optimal. Check in the gif below:

1) Feets are tipping and sometimes one foot get lost
2) When the base touches ground, all other contact disappear and then they come back again

This is a problem with DART's contact detection algorithm, we cannot do much here. I cc also @chapulina and @azeey for reference.

![out](https://user-images.githubusercontent.com/469199/84760973-12fbca80-afc9-11ea-9442-0d94198e1988.gif)
