### PR TITLE
Fix Panda visualization issues

### DIFF
--- a/gym_ignition_models/panda/meshes/visual/finger.dae
+++ b/gym_ignition_models/panda/meshes/visual/finger.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -60,7 +60,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>

--- a/gym_ignition_models/panda/meshes/visual/hand.dae
+++ b/gym_ignition_models/panda/meshes/visual/hand.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -60,7 +60,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -89,7 +89,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -118,7 +118,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -147,7 +147,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>

--- a/gym_ignition_models/panda/meshes/visual/link0.dae
+++ b/gym_ignition_models/panda/meshes/visual/link0.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -60,7 +60,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -89,7 +89,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -118,7 +118,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -147,7 +147,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -176,7 +176,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -205,7 +205,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -234,7 +234,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -263,7 +263,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -292,7 +292,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -321,7 +321,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -350,7 +350,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>

--- a/gym_ignition_models/panda/meshes/visual/link1.dae
+++ b/gym_ignition_models/panda/meshes/visual/link1.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>

--- a/gym_ignition_models/panda/meshes/visual/link2.dae
+++ b/gym_ignition_models/panda/meshes/visual/link2.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>

--- a/gym_ignition_models/panda/meshes/visual/link3.dae
+++ b/gym_ignition_models/panda/meshes/visual/link3.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -60,7 +60,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -89,7 +89,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -118,7 +118,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>

--- a/gym_ignition_models/panda/meshes/visual/link4.dae
+++ b/gym_ignition_models/panda/meshes/visual/link4.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -60,7 +60,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -89,7 +89,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -118,7 +118,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>

--- a/gym_ignition_models/panda/meshes/visual/link5.dae
+++ b/gym_ignition_models/panda/meshes/visual/link5.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -60,7 +60,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -89,7 +89,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>

--- a/gym_ignition_models/panda/meshes/visual/link6.dae
+++ b/gym_ignition_models/panda/meshes/visual/link6.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -60,7 +60,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -89,7 +89,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -118,7 +118,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -147,7 +147,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -176,7 +176,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -205,7 +205,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -234,7 +234,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -263,7 +263,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -292,7 +292,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -321,7 +321,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -350,7 +350,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -379,7 +379,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -408,7 +408,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -437,7 +437,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -466,7 +466,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -495,7 +495,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>

--- a/gym_ignition_models/panda/meshes/visual/link7.dae
+++ b/gym_ignition_models/panda/meshes/visual/link7.dae
@@ -31,7 +31,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -60,7 +60,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -89,7 +89,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -118,7 +118,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -147,7 +147,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -176,7 +176,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -205,7 +205,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>
@@ -234,7 +234,7 @@
             <shininess>
               <float sid="shininess">0</float>
             </shininess>
-            <transparent opaque="RGB_ZERO">
+            <transparent opaque="A_ONE">
               <color>1 1 1 1</color>
             </transparent>
             <index_of_refraction>


### PR DESCRIPTION
This PR is intended to fix visualization issue for the Panda robot. 

Given the most recent updates from https://github.com/ignitionrobotics/ign-rendering/issues/89, the `RGB_ZERO` transparent tags inserted in the Panda visual meshes to fix previous visualization issues need to be reverted to the original `A_ONE` value. 