### PR TITLE
Automatically set environment variables when used from Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,8 @@ If you want to make this change persistent, add the lines above to your `~/.bash
 
 #### Python usage
 
-If you're using the models from a Python program, we provide a helper function that updates the environment.
-Use the following code:
-
-```python
-import gym_ignition_models
-gym_ignition_models.setup_environment()
-```
-
-If you inspect the content of `os.environ` after this call, you'll find the environment variables already exported.
+The environment variables are automatically exported when the package is imported.
+If your application imports also the `scenario` package, make sure to import `gym_ignition_models` first.
 
 ### Usage
 

--- a/gym_ignition_models/__init__.py
+++ b/gym_ignition_models/__init__.py
@@ -115,3 +115,7 @@ def setup_environment() -> None:
             os.environ["IGN_FILE_PATH"] += f':{model_path}'
         else:
             os.environ["IGN_FILE_PATH"] = f'{model_path}'
+
+
+# Setup the environment when the package is imported
+setup_environment()


### PR DESCRIPTION
This PR simplifies downstream usage by automatically exporting the required environment variables during the Python package import process. It removes the need to remembering doing it when used downstream.

Furthermore, since the package init is executed only once even if the package is imported multiple times, there's no possibility to see the same content appended multiple times in the exported env variables as it would happen calling manually multiple times `setup_environment`.