### PR TITLE
Improve management of coulomb friction in iCub and ground_plane models

### DIFF
--- a/gym_ignition_models/ground_plane/ground_plane.sdf
+++ b/gym_ignition_models/ground_plane/ground_plane.sdf
@@ -12,7 +12,6 @@
                     <friction>
                         <ode>
                             <mu>100</mu>
-                            <mu2>50</mu2>
                         </ode>
                     </friction>
                 </surface>

--- a/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/icub_simple_collisions.urdf
+++ b/gym_ignition_models/iCubGazeboSimpleCollisionsV2_5/icub_simple_collisions.urdf
@@ -1552,6 +1552,11 @@
         <contact>
           <collide_bitmask>294</collide_bitmask>
         </contact>
+        <friction>
+          <ode>
+            <mu>1</mu>
+          </ode>
+        </friction>
       </surface>
     </collision>
   </gazebo>
@@ -1706,6 +1711,11 @@
         <contact>
           <collide_bitmask>198</collide_bitmask>
         </contact>
+        <friction>
+          <ode>
+            <mu>1</mu>
+          </ode>
+        </friction>
       </surface>
     </collision>
   </gazebo>


### PR DESCRIPTION
This PR closes https://github.com/robotology/gym-ignition-models/issues/23.

In particular, I configured the `mu` parameter of the ground plane to 100 so that it's very high and models that want to override this value can specify a smaller value. I did it for the iCub model. Furthermore, I removed the useless anisotropy created by `mu2`. 