### PR TITLE
Add restitution coefficient to ground plane

### DIFF
--- a/gym_ignition_models/ground_plane/ground_plane.sdf
+++ b/gym_ignition_models/ground_plane/ground_plane.sdf
@@ -14,6 +14,9 @@
                             <mu>100</mu>
                         </ode>
                     </friction>
+                    <bounce>
+                        <restitution_coefficient>1</restitution_coefficient>
+                    </bounce>
                 </surface>
             </collision>
             <visual name="visual">


### PR DESCRIPTION
Setting the coefficient of the ground to `1.0` does not change the behaviour of the simulation unless the other body in contact has a coefficient different from 0 (the default). 