### PR TITLE
Add Python helper that returns path, file, or string of URDF and SDF models (and, if needed, performs conversion)

### DIFF
--- a/gym_ignition_models/__init__.py
+++ b/gym_ignition_models/__init__.py
@@ -140,6 +140,12 @@ def get_model_resource(robot_name: str,
         robot_name: The name of the selected robot.
         resource_type: The type of the desired resource.
 
+    Note:
+        If a format conversion is performed, this method creates a temporary file.
+        If ``ResourceType.*_FILE`` is used, the file gets automatically deleted when
+        it goes out of scope. Instead, if ``ResourceType._*PATH`` is used, the caller
+        is responsible to delete it.
+
     Returns:
         The desired resource of the selected robot.
     """


### PR DESCRIPTION
This repository contains a mixed collection of SDF and URDF models. Until now, we offered the following two functions to get the resources:

https://github.com/robotology/gym-ignition-models/blob/9d3dafe0a7b75ef8af041c6974a2b6f1c1e36f58/gym_ignition_models/__init__.py#L35

https://github.com/robotology/gym-ignition-models/blob/9d3dafe0a7b75ef8af041c6974a2b6f1c1e36f58/gym_ignition_models/__init__.py#L67

This PR adds a new `get_model_resource` function that allows specifying the desired resource type. 

It implements the current logic:

- URDF models can be converted to SDF if `scenario` is installed.
- SDF models cannot be converted yet to SDF (https://github.com/osrf/sdformat/issues/273).
- If the model is converted, a temporary file is created.
  - If the resource type is `*_FILE`, the temp file is automatically deleted when it goes out of scope.
  - If the resource type is `*_PATH`, the caller is responsible to delete the temp file.